### PR TITLE
Set VERSION and SOVERSION for the shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project("Open Inventor"
     HOMEPAGE_URL "http://oss.sgi.com/projects/inventor/"
     LANGUAGES CXX C)
 
+set(INVENTOR_SOVERSION 1)
+
 include(GNUInstallDirs)
 include(FeatureSummary)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -848,9 +848,8 @@ if (CMAKE_DL_LIBS)
 endif()
 
 set_target_properties(Inventor PROPERTIES
-    #VERSION ${CMAKE_PROJECT_VERSION}
-    VERSION 0.0.0
-    SOVERSION 0
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${INVENTOR_SOVERSION}
 )
 
 install(TARGETS Inventor)

--- a/libSoXt/CMakeLists.txt
+++ b/libSoXt/CMakeLists.txt
@@ -115,9 +115,8 @@ target_sources(InventorXt
 )
 
 set_target_properties(InventorXt PROPERTIES
-    #VERSION ${CMAKE_PROJECT_VERSION}
-    VERSION 0.0.0
-    SOVERSION 0
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${INVENTOR_SOVERSION}
 )
 
 target_include_directories(InventorXt PRIVATE


### PR DESCRIPTION
Hello!  I'm the Debian package maintainer for open inventor.  I was delighted when an alert user pointed out your repository with consolidated patches and CMake build!  I have just reworked the Debian packages to use this repo as upstream.

I was able to remove all the Debian patches except this one - which sets the SO version.  I've set SOVERSION to 1 because that is what Debian has been using for over a decade.  I acknowledge that using the source major version is a more common convention so that would also be a reasonable choice.
